### PR TITLE
adding hidden {{lastUpdated}} to template so that observers are correctly setup

### DIFF
--- a/app/models/mixins/channel-serialization.js
+++ b/app/models/mixins/channel-serialization.js
@@ -3,7 +3,7 @@ import Step from './../step';
 var Serializer = Em.Mixin.create({
   lastUpdated: function() {
     return new Date();
-  }.property('sound', 'steps.length', 'steps.@each.lastUpdated'),
+  }.property('sound', 'steps.@each.lastUpdated'),
   serialize: function() {
     return {
       sound: this.get('sound'),

--- a/app/templates/components/channel-component.hbs
+++ b/app/templates/components/channel-component.hbs
@@ -47,3 +47,7 @@
     </button>
   </div>
 </span>
+
+<div style="display: none;">
+  {{channel.lastUpdated}}
+</div>


### PR DESCRIPTION
This is a quick fix, changing step models was not resulting in the [lastUpdated](https://github.com/GavinJoyce/ember-beats/blob/master/app/models/mixins/channel-serialization.js#L4) updating correctly.

I need to research why this hack is needed, I thought that getting the `lastUpdated` property `.on('init')` would be enough:

https://github.com/GavinJoyce/ember-beats/blob/master/app/models/channel.js#L15
